### PR TITLE
[mapcss parser] skip unknown mapcss attributes, emitting a warning

### DIFF
--- a/include/server/parser/mapcss_grammar.hpp
+++ b/include/server/parser/mapcss_grammar.hpp
@@ -237,6 +237,8 @@ struct MapCSSGrammar : public qi::grammar<GrammarIterator, StylesheetPtr(), qi::
 
 	//! Rule to parse a styleset of a rule
 	qi::rule<ItType, StylePtr(), qi::locals<shared_ptr<AttributeCreator>, ParseInfo>, Skipper> rule_styleset;
+	//! Rule to parse generic (unknown) attribute name
+	qi::rule<ItType, string(), Skipper> attribute_name;
 	//! Rule to parse the specifier
 	qi::rule<ItType, string(), Skipper> rule_specifier;
 	//! Rule to parse a value

--- a/include/server/parser/mapcss_parser.hpp
+++ b/include/server/parser/mapcss_parser.hpp
@@ -46,6 +46,7 @@ struct MapCssParser
 	SelectorPtr createSelectorFromBinaryCondition(const SelectorPtr& next, const shared_ptr<Rule>& rule, const BinaryCondition& condition);
 	SelectorPtr createSelectorFromCondition(const SelectorPtr& next, const shared_ptr<Rule>& rule, const ConditionType& condition);
 	RulePtr createSelectorChain(const std::vector<SelectorItem>& items);
+	void warnUnsupportedAttribute(const string& attribute) const;
 
 	MapCssParser(const shared_ptr<Geodata>& geodata);
 	void load(const string& path);

--- a/src/server/parser/mapcss_grammar.cpp
+++ b/src/server/parser/mapcss_grammar.cpp
@@ -150,14 +150,20 @@ MapCSSGrammar::MapCSSGrammar(MapCssParser& parser)
 
 	/******************************* Attributes *************************************/
 
+	attribute_name = +qi::char_("a-zA-Z_0-9-");
 	rule_specifier = ('\"' > +(qi::char_ - '\"') > '\"' ) | +(qi::char_ - ';' - '}');
 	rule_styleset = qi::eps[
 								_val = phx::construct<StylePtr>(phx::new_<StyleTemplate>())
 							]
 							>> -(
-									attributeType_[_a = _1]
-									>	':' > pip::pinfo[_b = _1]
-									>	rule_specifier[phx::bind(&MapCssParser::addAttributeToTemplate, &parser, _val, _a, _1, _b)]
+									(
+										attributeType_[_a = _1]
+										>	':' > pip::pinfo[_b = _1]
+										>	rule_specifier[phx::bind(&MapCssParser::addAttributeToTemplate, &parser, _val, _a, _1, _b)]
+									) | (
+										attribute_name[phx::bind(&MapCssParser::warnUnsupportedAttribute, &parser, _1)]
+										>   ':' > rule_specifier
+									)
 							) % ';'
 							>> -qi::lit(';');
 

--- a/src/server/parser/mapcss_parser.cpp
+++ b/src/server/parser/mapcss_parser.cpp
@@ -319,6 +319,15 @@ RulePtr MapCssParser::createSelectorChain(const std::vector<SelectorItem>& items
 }
 
 /**
+ * Emits a warning for unknown mapcss attribute
+ *
+ * \param attribute name
+ */
+void MapCssParser::warnUnsupportedAttribute(const string& attribute) const {
+	log.warnStream() << "Unsupported attribute '" << attribute << "' was ignored!";
+}
+
+/**
  *	Initializes the parser
  *
  *	\param geodata used in created rules


### PR DESCRIPTION
This makes porting existing styles easier
