### PR TITLE
WIP: Fix reading CachedString from a stream

### DIFF
--- a/include/utils/cached_string.hpp
+++ b/include/utils/cached_string.hpp
@@ -210,7 +210,9 @@ inline bool operator !=(const MaybeCachedString& first, const MaybeCachedString&
 template<typename Stream>
 Stream& operator >> (Stream& stream, CachedString& str)
 {
-	str = CachedString(static_cast<std::stringstream const&>(std::stringstream() << stream.rdbuf()).str());
+	std::string s;
+	stream >> s;
+	str = CachedString(s);
 
 	return stream;
 }


### PR DESCRIPTION
At least with clang/libc++, std::stringstream() << stream.rdbuf()
doesn't terminate reading from streambuf neither on end of token
nor on end of buf, reading past the end of buffer and leading to
segfault. Just reading a token into a string seem to simplier and
more reliable.
