### PR TITLE
Restore MSVC compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,20 +13,6 @@ if (NOT Boost_FOUND)
     message(FATAL_ERROR "Fatal error: Boost (version >= 1.47.0) required.\n")
 endif (NOT Boost_FOUND)
 
-# Check if boost compiles with libc.
-set(CMAKE_REQUIRED_INCLUDES ${Boost_INCLUDE_DIRS})
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles("
-#include <boost/thread/xtime.hpp>
-int main(void)
-{
-    return 0;
-}
-" BOOST_XTIME)
-if (NOT BOOST_XTIME)
-    message (FATAL_ERROR "Fatal error: Boost xtime seems to be broken. Consider upgrading Boost to >= 1.50")
-endif()
-
 #find other packages
 IF(WIN32)
 	SET(ENV{FREETYPE_DIR} ${CMAKE_FIND_ROOT_PATH})
@@ -38,6 +24,7 @@ find_package(Cairo REQUIRED)
 find_package(Freetype REQUIRED)
 find_package(Log4Cpp REQUIRED)
 
+find_package(Threads REQUIRED)
 find_package(Doxygen)
 
 # FIXME hack for log4cpp backward compability
@@ -83,9 +70,6 @@ set(TEST_DIRECTORY "${CMAKE_SOURCE_DIR}/tests")
 link_directories(${Boost_LIBRARY_DIRS})
 include_directories(include ${Boost_INCLUDE_DIRS} ${CAIRO_INCLUDE_DIR} ${FREETYPE_INCLUDE_DIRS} ${Log4Cpp_INCLUDE_DIRS})
 
-ADD_DEFINITIONS("-std=c++11")
-#ADD_DEFINITIONS("-fdiagnostics-color=auto")
-ADD_DEFINITIONS(-DBOOST_TEST_DYN_LINK)
 ADD_DEFINITIONS(${Log4Cpp_DEFINITIONS})
 ADD_DEFINITIONS(-DStatistic_Activated)
 
@@ -97,10 +81,20 @@ IF(EXISTS "${PROJECT_SOURCE_DIR}/gmock" AND IS_DIRECTORY "${PROJECT_SOURCE_DIR}/
     SET(GMOCK_FOUND 1)
 ENDIF(EXISTS "${PROJECT_SOURCE_DIR}/gmock" AND IS_DIRECTORY "${PROJECT_SOURCE_DIR}/gmock")
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-SET(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ftest-coverage -fprofile-arcs -fprofile-values -fvpt -pg")
-SET(CMAKE_CXX_FLAGS_SANITIZE "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=thread -fno-omit-frame-pointer")
+if(MSVC)
+   ADD_DEFINITIONS(-D_WIN32_WINNT=0x0501)
+   ADD_DEFINITIONS(-DNOMINMAX)
+   ADD_DEFINITIONS(-D_USE_MATH_DEFINES)
+else()
+   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+   SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+   SET(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ftest-coverage -fprofile-arcs -fprofile-values -fvpt -pg")
+   SET(CMAKE_CXX_FLAGS_SANITIZE "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=thread -fno-omit-frame-pointer")
+   ADD_DEFINITIONS("-std=c++11")
+   #ADD_DEFINITIONS("-fdiagnostics-color=auto")
+   ADD_DEFINITIONS(-DBOOST_TEST_DYN_LINK)
+endif()
+
 MARK_AS_ADVANCED(CMAKE_CXX_FLAGS_PROFILE)
 SET( CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
     "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel Profile Sanitize."
@@ -148,6 +142,7 @@ configure_file("include/config.hpp.in" "${CMAKE_SOURCE_DIR}/include/config.hpp")
 
 add_executable(alacarte-server      src/alacarte_server.cpp     ${server_sources}   ${alacarte_sources})
 add_executable(alacarte-importer    src/alacarte_importer.cpp   ${importer_sources} ${alacarte_sources})
+
 add_executable(unitTests_utils      EXCLUDE_FROM_ALL ${UnitTests_utils_sources} ${alacarte_sources} ${UnitTests_shared_sources})
 add_executable(unitTests_parser     EXCLUDE_FROM_ALL ${UnitTests_parser_sources} ${alacarte_sources} ${server_sources} ${UnitTests_shared_sources})
 add_executable(unitTests_general    EXCLUDE_FROM_ALL ${UnitTests_general_sources} ${alacarte_sources} ${UnitTests_shared_sources})
@@ -168,17 +163,17 @@ IF(GMOCK_FOUND)
     set_target_properties(unitTests_mapcss PROPERTIES COMPILE_DEFINITIONS "ALACARTE_TEST")
 ENDIF(GMOCK_FOUND)
 
-target_link_libraries(alacarte-server       ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${Log4Cpp_LIBRARIES} pthread ${SYSTEM_LIBRARIES})
-target_link_libraries(alacarte-importer     ${Boost_LIBRARIES} ${Log4Cpp_LIBRARIES} pthread ${SYSTEM_LIBRARIES})
-target_link_libraries(unitTests_utils       ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${Log4Cpp_LIBRARIES} pthread)
-target_link_libraries(unitTests_general     ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${Log4Cpp_LIBRARIES} pthread)
-target_link_libraries(unitTests_importer    ${Boost_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CAIRO_LIBRARIES} pthread)
-target_link_libraries(unitTests_server      ${Boost_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CAIRO_LIBRARIES} pthread)
-target_link_libraries(unitTests_parser      ${Boost_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CAIRO_LIBRARIES} pthread)
+target_link_libraries(alacarte-server       ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SYSTEM_LIBRARIES})
+target_link_libraries(alacarte-importer     ${Boost_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SYSTEM_LIBRARIES})
+target_link_libraries(unitTests_utils       ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(unitTests_general     ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(unitTests_importer    ${Boost_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(unitTests_server      ${Boost_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(unitTests_parser      ${Boost_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 IF(GMOCK_FOUND)
-    target_link_libraries(unitTests_mapcss  ${Boost_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CAIRO_LIBRARIES} pthread gmock gtest)
+    target_link_libraries(unitTests_mapcss  ${Boost_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} gmock gtest)
 ENDIF(GMOCK_FOUND)
-target_link_libraries(unitTests_eval        ${Boost_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CAIRO_LIBRARIES} pthread)
+target_link_libraries(unitTests_eval        ${Boost_LIBRARIES} ${Log4Cpp_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 set(test_files "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/karlsruhe_big.carte" "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/renderer_test.carte" "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/test_tiles.carte")
 

--- a/extras/dirwatch/windows/basic_dir_monitor_service.hpp
+++ b/extras/dirwatch/windows/basic_dir_monitor_service.hpp
@@ -212,7 +212,7 @@ private:
 			DWORD bytes_transferred; 
 			completion_key *ck; 
 			OVERLAPPED *overlapped; 
-			BOOL res = GetQueuedCompletionStatus(iocp_, &bytes_transferred, reinterpret_cast<unsigned long*>(&ck), &overlapped, INFINITE); 
+			BOOL res = GetQueuedCompletionStatus(iocp_, &bytes_transferred, reinterpret_cast<PULONG_PTR>(&ck), &overlapped, INFINITE); 
 			if (!res) 
 			{ 
 				DWORD last_error = GetLastError(); 

--- a/include/general/rtree.hpp
+++ b/include/general/rtree.hpp
@@ -359,6 +359,9 @@ void RTree<id_t, data_t>::buildLevels ()
 
 //! reads a leaf from file
 template<class id_t, class data_t>
+#ifdef _MSC_VER
+typename
+#endif
 RTree<id_t, data_t>::RLeaf<id_t, data_t>*
 RTree<id_t, data_t>::readLeaf (uint32_t nodeIdx, uint32_t childIdx) const
 {

--- a/include/server/request_manager.hpp
+++ b/include/server/request_manager.hpp
@@ -22,6 +22,7 @@
 #define REQUEST_MANAGER_HPP
 
 
+#include <chrono>
 #include <boost/asio.hpp>
 #include <boost/thread/thread.hpp>
 
@@ -85,7 +86,7 @@ private:
 
 	log4cpp::Category& log;
 
-	timeval prerender_start, prerender_stop;
+	std::chrono::system_clock::time_point prerender_start, prerender_stop;
 };
 
 

--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -80,12 +80,6 @@
 										}															\
 									}
 
-#define TIMER_START(_X) timeval _X##_start, _X##_stop; gettimeofday(&_X##_start, NULL)
-#define TIMER_STOP(_X) gettimeofday(&_X##_stop, NULL);
-#define TIMER_MSEC(_X) ((_X##_stop.tv_sec - _X##_start.tv_sec) * 1000.0 + (_X##_stop.tv_usec - _X##_start.tv_usec) / 1000.0)
-#define TIMER_SEC(_X) ((_X##_stop.tv_sec - _X##_start.tv_sec) + (_X##_stop.tv_usec - _X##_start.tv_usec) / 1000.0 / 1000.0)
-#define TIMER_MIN(_X) ((_X##_stop.tv_sec - _X##_start.tv_sec) / 60.0)
-
 using boost::shared_ptr;
 using boost::scoped_ptr;
 using boost::weak_ptr;

--- a/src/server/eval/unary_operation_node.cpp
+++ b/src/server/eval/unary_operation_node.cpp
@@ -33,10 +33,14 @@ UnaryOperationNode::UnaryOperationNode(op::UnaryOperationEnum operation, const n
 
 }
 
+/**
+ * This method does nothing for now as UnaryOperations are not used in parser
+ */
 string UnaryOperationNode::eval(GeoObject* obj) const
 {
-	// This is needed beacase of MSVC
 	assert(false);
+	// This is needed because of MSVC
+	return "";
 }
 
 

--- a/src/server/request_manager.cpp
+++ b/src/server/request_manager.cpp
@@ -106,7 +106,7 @@ RequestManager::RequestManager( const shared_ptr<Configuration>& config,
 	}
 
 	// start prerender timing
-	gettimeofday(&prerender_start, NULL);
+        prerender_start = std::chrono::system_clock::now();
 }
 
 /**
@@ -287,8 +287,10 @@ bool RequestManager::nextPreRenderRequest()
 	preLock.unlock();
 
 	if (currentPrerenderingThreads == 0 && preRenderRequests.size() == 0) {
-		TIMER_STOP(prerender);
-		log.info("Prerendering finished in %02i:%02i", (int) TIMER_MIN(prerender), ((int) TIMER_SEC(prerender)) % 60);
+		prerender_stop = std::chrono::system_clock::now();
+                int elapsed_seconds = std::chrono::duration_cast<std::chrono::seconds>
+                             (prerender_stop-prerender_start).count();
+		log.info("Prerendering finished in %02i:%02i", elapsed_seconds / 60, elapsed_seconds % 60);
 	}
 
 	return true;


### PR DESCRIPTION
Here are the minimal changes to restore Windows compatibility (tested on Visual Studio 2015, eliminated compile errors).
To compile and run tests, more changes are needed.