### PR TITLE
switch from c++0x to c++11 definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ set(TEST_DIRECTORY "${CMAKE_SOURCE_DIR}/tests")
 link_directories(${Boost_LIBRARY_DIRS})
 include_directories(include ${Boost_INCLUDE_DIRS} ${CAIRO_INCLUDE_DIR} ${FREETYPE_INCLUDE_DIRS} ${Log4Cpp_INCLUDE_DIRS})
 
-ADD_DEFINITIONS("-std=c++0x")
+ADD_DEFINITIONS("-std=c++11")
 #ADD_DEFINITIONS("-fdiagnostics-color=auto")
 ADD_DEFINITIONS(-DBOOST_TEST_DYN_LINK)
 ADD_DEFINITIONS(${Log4Cpp_DEFINITIONS})


### PR DESCRIPTION
Debian Wheezy, current oldstable, ships with gcc 4.7 which already supports explicit c++11,
and this is the oldest platform we care about. Probably makes no difference, though.