### PR TITLE
Speed-up compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ before_install:
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
   #new cairo
   - sudo add-apt-repository --yes ppa:ricotz/testing
-
+  # new cmake
+  - sudo add-apt-repository --yes ppa:kalakris/cmake
   - sudo apt-get update -qq
   - sudo apt-get install -qq cmake g++-4.8 libboost1.55-all-dev libboost-log1.55-dev libcairo2-dev libpng12-dev
 
@@ -27,7 +28,8 @@ script:
   - ./unitTests_general
   - ./unitTests_utils
   - ./unitTests_parser
-  - ./unitTests_server
+  - ./unitTests_eval
+# - ./unitTests_server # skip for now until the test is fixed
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,17 +19,11 @@ before_install:
 before_script:
   - mkdir build
   - cd build
-  - cmake ..
+  - cmake .. -DBUILD_TESTING=ON
 
 script:
   - make
-  - make tests
-  - ./unitTests_importer
-  - ./unitTests_general
-  - ./unitTests_utils
-  - ./unitTests_parser
-  - ./unitTests_eval
-# - ./unitTests_server # skip for now until the test is fixed
+  - ctest -VV -E unitTests_server
 
 notifications:
   email:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,13 @@ cmake_minimum_required( VERSION 2.8.8 )
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+include(CTest)
+
 #
 # Depends on boost version from Debian Jessie
 #
 find_package(Boost 1.55.0 COMPONENTS system filesystem thread unit_test_framework program_options serialization regex
 	iostreams log log_setup REQUIRED)
-
-OPTION(BUILD_TESTS "Build tests automatically and allow running them with ctest" OFF)
 
 if (NOT Boost_FOUND)
     message(FATAL_ERROR "Fatal error: Boost (version >= 1.55.0) required.\n")
@@ -196,7 +196,7 @@ add_custom_command(
     COMMAND alacarte-importer "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/renderer_test.osm" "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/renderer_test.carte"
 )
 
-IF(BUILD_TESTS)
+IF(BUILD_TESTING)
    SET(BT_FLAG ALL)
 ENDIF()
 
@@ -204,9 +204,7 @@ add_custom_target(tests ${BT_FLAG}
     DEPENDS alacarte-importer unitTests_server unitTests_importer unitTests_general unitTests_parser unitTests_utils unitTests_eval ${test_files}
 )
 
-IF(BUILD_TESTS)
-   enable_testing()
-   include(CTest)
+IF(BUILD_TESTING)
    add_test(unitTests_utils unitTests_utils DEPENDS tests)
    add_test(unitTests_eval unitTests_eval)
    add_test(unitTests_parser unitTests_parser)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(alacarte)
 
-cmake_minimum_required( VERSION 2.8 )
+cmake_minimum_required( VERSION 2.8.8 )
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(Boost 1.55.0 COMPONENTS system filesystem thread unit_test_framework program_options serialization regex
 	iostreams log log_setup REQUIRED)
 
+OPTION(BUILD_TESTS "Build tests automatically and allow running them with ctest" OFF)
+
 if (NOT Boost_FOUND)
     message(FATAL_ERROR "Fatal error: Boost (version >= 1.55.0) required.\n")
 endif (NOT Boost_FOUND)
@@ -160,6 +162,7 @@ add_executable(unitTests_parser    EXCLUDE_FROM_ALL ${UnitTests_parser_sources} 
 add_executable(unitTests_general   EXCLUDE_FROM_ALL ${UnitTests_general_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
 add_executable(unitTests_importer  EXCLUDE_FROM_ALL ${UnitTests_importer_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:alacarte-obj-test>)
 add_executable(unitTests_server    EXCLUDE_FROM_ALL ${UnitTests_server_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
+
 IF(GMOCK_FOUND)
     add_executable(unitTests_mapcss EXCLUDE_FROM_ALL ${UnitTests_mapcss_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
 ENDIF(GMOCK_FOUND)
@@ -193,9 +196,27 @@ add_custom_command(
     COMMAND alacarte-importer "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/renderer_test.osm" "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/renderer_test.carte"
 )
 
-add_custom_target(tests
+IF(BUILD_TESTS)
+   SET(BT_FLAG ALL)
+ENDIF()
+
+add_custom_target(tests ${BT_FLAG}
     DEPENDS alacarte-importer unitTests_server unitTests_importer unitTests_general unitTests_parser unitTests_utils unitTests_eval ${test_files}
 )
+
+IF(BUILD_TESTS)
+   enable_testing()
+   include(CTest)
+   add_test(unitTests_utils unitTests_utils DEPENDS tests)
+   add_test(unitTests_eval unitTests_eval)
+   add_test(unitTests_parser unitTests_parser)
+   add_test(unitTests_general unitTests_general)
+   add_test(unitTests_importer unitTests_importer)
+   add_test(unitTests_server unitTests_server)
+IF(GMOCK_FOUND)
+   add_test(unitTests_mapcss unitTests_mapcss)
+ENDIF(GMOCK_FOUND)
+ENDIF()
 
 #
 # Add cpplint target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,28 +138,32 @@ configure_file("data/config/alacarte.conf.in" "${CMAKE_SOURCE_DIR}/data/config/a
 configure_file("tests/config.hpp.in" "${CMAKE_SOURCE_DIR}/tests/config.hpp")
 configure_file("include/config.hpp.in" "${CMAKE_SOURCE_DIR}/include/config.hpp")
 
-add_executable(alacarte-server      src/alacarte_server.cpp     ${server_sources}   ${alacarte_sources})
-add_executable(alacarte-importer    src/alacarte_importer.cpp   ${importer_sources} ${alacarte_sources})
+add_library(alacarte-obj OBJECT ${alacarte_sources})
+add_library(server-obj OBJECT ${server_sources})
 
-add_executable(unitTests_utils      EXCLUDE_FROM_ALL ${UnitTests_utils_sources} ${alacarte_sources} ${UnitTests_shared_sources})
-add_executable(unitTests_parser     EXCLUDE_FROM_ALL ${UnitTests_parser_sources} ${alacarte_sources} ${server_sources} ${UnitTests_shared_sources})
-add_executable(unitTests_general    EXCLUDE_FROM_ALL ${UnitTests_general_sources} ${alacarte_sources} ${UnitTests_shared_sources})
-add_executable(unitTests_importer   EXCLUDE_FROM_ALL ${UnitTests_importer_sources} ${UnitTests_shared_sources} ${importer_source} ${alacarte_sources})
-add_executable(unitTests_server     EXCLUDE_FROM_ALL ${UnitTests_server_sources} ${UnitTests_shared_sources} ${server_sources} ${alacarte_sources})
-IF(GMOCK_FOUND)
-    add_executable(unitTests_mapcss EXCLUDE_FROM_ALL ${UnitTests_mapcss_sources} ${UnitTests_shared_sources} ${server_sources} ${alacarte_sources})
-ENDIF(GMOCK_FOUND)
-add_executable(unitTests_eval       EXCLUDE_FROM_ALL ${UnitTests_eval_sources} ${UnitTests_shared_sources} ${server_sources} ${alacarte_sources})
+add_executable(alacarte-server      src/alacarte_server.cpp     $<TARGET_OBJECTS:server-obj> $<TARGET_OBJECTS:alacarte-obj>)
+add_executable(alacarte-importer    src/alacarte_importer.cpp   ${importer_sources} $<TARGET_OBJECTS:alacarte-obj>)
 
-set_target_properties(unitTests_eval       PROPERTIES COMPILE_DEFINITIONS "ALACARTE_TEST")
-set_target_properties(unitTests_general    PROPERTIES COMPILE_DEFINITIONS "ALACARTE_TEST")
-set_target_properties(unitTests_utils      PROPERTIES COMPILE_DEFINITIONS "ALACARTE_TEST")
-set_target_properties(unitTests_parser     PROPERTIES COMPILE_DEFINITIONS "ALACARTE_TEST")
-set_target_properties(unitTests_eval       PROPERTIES COMPILE_DEFINITIONS "ALACARTE_TEST")
-set_target_properties(unitTests_server     PROPERTIES COMPILE_DEFINITIONS "ALACARTE_TEST")
+#
+#  Building tests
+#  All sources are rebuilt with ALACARTE_TEST (it is used in .cpp files)
+#
+
+add_definitions(-DALACARTE_TEST)
+
+add_library(alacarte-obj-test EXCLUDE_FROM_ALL OBJECT ${alacarte_sources})
+add_library(server-obj-test EXCLUDE_FROM_ALL OBJECT ${server_sources})
+add_library(UnitTests-shared-obj EXCLUDE_FROM_ALL OBJECT ${UnitTests_shared_sources})
+
+add_executable(unitTests_utils     EXCLUDE_FROM_ALL ${UnitTests_utils_sources}  $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:alacarte-obj-test>)
+add_executable(unitTests_parser    EXCLUDE_FROM_ALL ${UnitTests_parser_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
+add_executable(unitTests_general   EXCLUDE_FROM_ALL ${UnitTests_general_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
+add_executable(unitTests_importer  EXCLUDE_FROM_ALL ${UnitTests_importer_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:alacarte-obj-test>)
+add_executable(unitTests_server    EXCLUDE_FROM_ALL ${UnitTests_server_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
 IF(GMOCK_FOUND)
-    set_target_properties(unitTests_mapcss PROPERTIES COMPILE_DEFINITIONS "ALACARTE_TEST")
+    add_executable(unitTests_mapcss EXCLUDE_FROM_ALL ${UnitTests_mapcss_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
 ENDIF(GMOCK_FOUND)
+add_executable(unitTests_eval       EXCLUDE_FROM_ALL ${UnitTests_eval_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
 
 target_link_libraries(alacarte-server       ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SYSTEM_LIBRARIES})
 target_link_libraries(alacarte-importer     ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SYSTEM_LIBRARIES})
@@ -190,15 +194,22 @@ add_custom_command(
 )
 
 add_custom_target(tests
-    DEPENDS alacarte-importer unitTests_server unitTests_importer unitTests_general unitTests_parser unitTests_utils ${test_files}
+    DEPENDS alacarte-importer unitTests_server unitTests_importer unitTests_general unitTests_parser unitTests_utils unitTests_eval ${test_files}
 )
 
+#
+# Add cpplint target
+#
 add_custom_target(lint
 	COMMAND cpplint --filter=-whitespace --extensions=c,h,cpp,hpp ${server_sources} ${importer_source} ${alacarte_sources}
 	COMMENT "Check if there are style violations" VERBATIM
 )
 
+
+#
+# Generate documentation
 # add a target to generate API documentation with Doxygen
+#
 if(DOXYGEN_FOUND)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/doc.doxy ${CMAKE_CURRENT_BINARY_DIR}/doc.doxy @ONLY)
     add_custom_target(doc ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/doc.doxy


### PR DESCRIPTION
Now when the tests are building on Travis one can see that most sources are compiled multiple times (alacarte-sources and server-sources for almst every test).

We can introduce separate libraries for that sources or use CMake feature called "object ibraries" (just reusing .o files, actually). To use Object libraries we have to upgrade CMake to 2.8.8:
https://cmake.org/Wiki/CMake/Tutorials/Object_Library
If we want to support older cmake, usual libraries can be introduced too. There can potentially be template-related problems if new template combinations will be used in the code without that variant in built cpp.

Here is a commit to compare with old build process.