### PR TITLE
[cmake] Move unit tests in a separate CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,6 @@ cmake_minimum_required( VERSION 2.8.8 )
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-include(CTest)
-
-
 set(SYSCONFDIR "${CMAKE_INSTALL_PREFIX}/etc")
 if (CMAKE_INSTALL_PREFIX STREQUAL "/usr"
  OR CMAKE_INSTALL_PREFIX STREQUAL "/usr/local")
@@ -18,11 +15,24 @@ add_subdirectory(manpages)
 #
 # Depends on boost version from Debian Jessie
 #
-find_package(Boost 1.55.0 COMPONENTS system filesystem thread unit_test_framework program_options serialization regex
-	iostreams log log_setup REQUIRED)
+set(BOOST_MIN_VERSION_REQUIRED 1.55.0)
+find_package(Boost ${BOOST_MIN_VERSION_REQUIRED} COMPONENTS
+	system
+	filesystem
+	thread 
+	# TODO unit_test_framework is only needed for unit tests, so move it to tests/CMakeLists.txt
+	unit_test_framework
+	program_options
+	serialization
+	regex
+	iostreams
+	log
+	log_setup
+	REQUIRED
+)
 
 if (NOT Boost_FOUND)
-    message(FATAL_ERROR "Fatal error: Boost (version >= 1.55.0) required.\n")
+    message(FATAL_ERROR "Fatal error: Boost (version >= ${BOOST_MIN_VERSION_REQUIRED}) required.\n")
 endif (NOT Boost_FOUND)
 
 #find other packages
@@ -33,6 +43,9 @@ ELSE(WIN32)
 ENDIF(WIN32)
 
 find_package(Cairo REQUIRED)
+if(CAIRO_FOUND)
+	message(STATUS "Cairo Verison: ${CAIRO_VERSION}")
+endif()
 find_package(Freetype REQUIRED)
 
 find_package(Threads REQUIRED)
@@ -48,16 +61,16 @@ if(CAIRO_VERSION_V LESS 1 OR CAIRO_VERSION_MAJOR LESS 12 OR CAIRO_VERSION_MINOR 
     if(MINGW)
         message (STATUS "MinGW detected: enabling render lock.")
     else(MINGW)
-        message (STATUS "${Cairo_VERSION} < 1.12.2: enabling render lock.")
+        message (STATUS "${CAIRO_VERSION} < 1.12.2: enabling render lock.")
     endif(MINGW)
-else(CAIRO_VERSION_V LESS 1 OR CAIRO_VERSION_MAJOR LESS 12 OR CAIRO_VERSION_MINOR LESS 2 OR MINGW)
+else()
     OPTION(RENDER_LOCK "Render lock for old cairo and Windows" OFF)
-endif(CAIRO_VERSION_V LESS 1 OR CAIRO_VERSION_MAJOR LESS 12 OR CAIRO_VERSION_MINOR LESS 2 OR MINGW)
+endif()
 if(RENDER_LOCK)
     set(RENDER_LOCK 1)
-else(RENDER_LOCK)
+else()
     set(RENDER_LOCK 0)
-endif (RENDER_LOCK)
+endif()
 
 # Set windows version for MinGW and Inotify for non-mingw targets
 IF(MINGW)
@@ -69,20 +82,10 @@ ELSE(MINGW)
     set(SYSTEM_LIBRARIES ${INOTIFY_LIBRARY})
 ENDIF(MINGW)
 
-set(TEST_DIRECTORY "${CMAKE_SOURCE_DIR}/tests")
-
 link_directories(${Boost_LIBRARY_DIRS})
 include_directories(include ${Boost_INCLUDE_DIRS} ${CAIRO_INCLUDE_DIR} ${FREETYPE_INCLUDE_DIRS})
 
-ADD_DEFINITIONS(-DStatistic_Activated)
-
-# check for local static build gmock directory
-SET(GMOCK_FOUND 0)
-IF(EXISTS "${PROJECT_SOURCE_DIR}/gmock" AND IS_DIRECTORY "${PROJECT_SOURCE_DIR}/gmock")
-    link_directories(${Boost_LIBRARY_DIRS} ${Cairo_LIBRARY_DIRS} "${PROJECT_SOURCE_DIR}/gmock")
-    message("gmock dir found\n")
-    SET(GMOCK_FOUND 1)
-ENDIF(EXISTS "${PROJECT_SOURCE_DIR}/gmock" AND IS_DIRECTORY "${PROJECT_SOURCE_DIR}/gmock")
+add_definitions(-DStatistic_Activated)
 
 if(MSVC)
    ADD_DEFINITIONS(-D_WIN32_WINNT=0x0501)
@@ -117,14 +120,20 @@ endif ()
 if (CMAKE_BUILD_TYPE STREQUAL "Sanitize")
     set(DEBUG_BUILD 1)
 endif ()
-message (STATUS "Enabling debug code: ${DEBUG_BUILD}")
+if (DEBUG_BUILD)
+	message (STATUS "Debug code enabled (DEBUG_BUILD macro set)")
+else()
+	message (STATUS "Debug code disabled (DEBUG_BUILD macro not set)")
+endif()
 
-message(STATUS "Default: ${CMAKE_CXX_FLAGS}")
-message(STATUS "Debug: ${CMAKE_CXX_FLAGS_DEBUG}")
-message(STATUS "Profile: ${CMAKE_CXX_FLAGS_PROFILE}")
-message(STATUS "Release: ${CMAKE_CXX_FLAGS_RELEASE}")
-message(STATUS "Sanitize: ${CMAKE_CXX_FLAGS_SANITIZE}")
-
+message(STATUS "Compile Flags:")
+message(STATUS "-----------------")
+message(STATUS "| Default : ${CMAKE_CXX_FLAGS}")
+message(STATUS "| Debug   : ${CMAKE_CXX_FLAGS_DEBUG}")
+message(STATUS "| Profile : ${CMAKE_CXX_FLAGS_PROFILE}")
+message(STATUS "| Release : ${CMAKE_CXX_FLAGS_RELEASE}")
+message(STATUS "| Sanitize: ${CMAKE_CXX_FLAGS_SANITIZE}")
+message(STATUS "-----------------")
 
 
 #
@@ -133,20 +142,12 @@ message(STATUS "Sanitize: ${CMAKE_CXX_FLAGS_SANITIZE}")
 file(GLOB_RECURSE server_sources                src/server/*.cpp)
 file(GLOB_RECURSE importer_sources              src/importer/*.cpp)
 file(GLOB_RECURSE alacarte_sources              src/general/*.cpp src/utils/*.cpp)
-file(GLOB_RECURSE UnitTests_general_sources     tests/general/*.cpp)
-file(GLOB_RECURSE UnitTests_server_sources      tests/server/*.cpp)
-file(GLOB_RECURSE UnitTests_mapcss_sources      tests/mapcss/*.cpp)
-file(GLOB_RECURSE UnitTests_importer_sources    tests/importer/*.cpp)
-file(GLOB_RECURSE UnitTests_utils_sources       tests/utils/*.cpp)
-file(GLOB_RECURSE UnitTests_eval_sources        tests/eval/*.cpp)
-file(GLOB_RECURSE UnitTests_parser_sources      tests/parser/*.cpp)
-file(GLOB_RECURSE UnitTests_shared_sources      tests/shared/*.cpp)
+
 
 #
 # Targets
 #
 configure_file("data/config/alacarte-maps.conf.in" "${CMAKE_SOURCE_DIR}/data/config/alacarte-maps.conf")
-configure_file("tests/config.hpp.in" "${CMAKE_SOURCE_DIR}/tests/config.hpp")
 configure_file("include/config.hpp.in" "${CMAKE_SOURCE_DIR}/include/config.hpp")
 
 add_library(alacarte-obj OBJECT ${alacarte_sources})
@@ -155,75 +156,19 @@ add_library(server-obj OBJECT ${server_sources})
 add_executable(alacarte-maps-server      src/alacarte_server.cpp     $<TARGET_OBJECTS:server-obj> $<TARGET_OBJECTS:alacarte-obj>)
 add_executable(alacarte-maps-importer    src/alacarte_importer.cpp   ${importer_sources} $<TARGET_OBJECTS:alacarte-obj>)
 
-#
-#  Building tests
-#  All sources are rebuilt with ALACARTE_TEST (it is used in .cpp files)
-#
-
-add_definitions(-DALACARTE_TEST)
-
-add_library(alacarte-obj-test EXCLUDE_FROM_ALL OBJECT ${alacarte_sources})
-add_library(server-obj-test EXCLUDE_FROM_ALL OBJECT ${server_sources})
-add_library(UnitTests-shared-obj EXCLUDE_FROM_ALL OBJECT ${UnitTests_shared_sources})
-
-add_executable(unitTests_utils     EXCLUDE_FROM_ALL ${UnitTests_utils_sources}  $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:alacarte-obj-test>)
-add_executable(unitTests_parser    EXCLUDE_FROM_ALL ${UnitTests_parser_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
-add_executable(unitTests_general   EXCLUDE_FROM_ALL ${UnitTests_general_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
-add_executable(unitTests_importer  EXCLUDE_FROM_ALL ${UnitTests_importer_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:alacarte-obj-test>)
-add_executable(unitTests_server    EXCLUDE_FROM_ALL ${UnitTests_server_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
-
-IF(GMOCK_FOUND)
-    add_executable(unitTests_mapcss EXCLUDE_FROM_ALL ${UnitTests_mapcss_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
-ENDIF(GMOCK_FOUND)
-add_executable(unitTests_eval       EXCLUDE_FROM_ALL ${UnitTests_eval_sources} $<TARGET_OBJECTS:UnitTests-shared-obj> $<TARGET_OBJECTS:server-obj-test> $<TARGET_OBJECTS:alacarte-obj-test>)
-
 target_link_libraries(alacarte-maps-server       ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SYSTEM_LIBRARIES})
 target_link_libraries(alacarte-maps-importer     ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SYSTEM_LIBRARIES})
-target_link_libraries(unitTests_utils       ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-target_link_libraries(unitTests_general     ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-target_link_libraries(unitTests_importer    ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-target_link_libraries(unitTests_server      ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SYSTEM_LIBRARIES})
-target_link_libraries(unitTests_parser      ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SYSTEM_LIBRARIES})
-IF(GMOCK_FOUND)
-    target_link_libraries(unitTests_mapcss  ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} gmock gtest)
-ENDIF(GMOCK_FOUND)
-target_link_libraries(unitTests_eval        ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SYSTEM_LIBRARIES})
 
 
-set(test_files "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/karlsruhe_big.carte" "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/renderer_test.carte" "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/test_tiles.carte")
+option(BUILD_TESTING "Build unit tests" OFF)
+if(BUILD_TESTING)
+	message(STATUS "Building unit tests enabled")
+	enable_testing()
+	add_subdirectory(tests)
+else()
+	message(STATUS "Building unit tests disabled")
+endif()
 
-add_custom_command(
-    OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/karlsruhe_big.carte"
-    COMMAND alacarte-maps-importer "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/karlsruhe_big.osm" "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/karlsruhe_big.carte"
-)
-add_custom_command(
-    OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/test_tiles.carte"
-    COMMAND alacarte-maps-importer "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/test_tiles.osm" "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/test_tiles.carte"
-)
-add_custom_command(
-    OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/renderer_test.carte"
-    COMMAND alacarte-maps-importer "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/renderer_test.osm" "${CMAKE_CURRENT_SOURCE_DIR}/tests/data/input/renderer_test.carte"
-)
-
-IF(BUILD_TESTING)
-   SET(BT_FLAG ALL)
-ENDIF()
-
-add_custom_target(tests ${BT_FLAG}
-    DEPENDS alacarte-maps-importer unitTests_server unitTests_importer unitTests_general unitTests_parser unitTests_utils unitTests_eval ${test_files}
-)
-
-IF(BUILD_TESTING)
-   add_test(unitTests_utils unitTests_utils DEPENDS tests)
-   add_test(unitTests_eval unitTests_eval)
-   add_test(unitTests_parser unitTests_parser)
-   add_test(unitTests_general unitTests_general)
-   add_test(unitTests_importer unitTests_importer)
-   add_test(unitTests_server unitTests_server)
-IF(GMOCK_FOUND)
-   add_test(unitTests_mapcss unitTests_mapcss)
-ENDIF(GMOCK_FOUND)
-ENDIF()
 
 #
 # Add cpplint target
@@ -246,10 +191,10 @@ if(DOXYGEN_FOUND)
     )
 endif(DOXYGEN_FOUND)
 
+
 #
 # Installation
 #
-
 install(TARGETS alacarte-maps-server RUNTIME DESTINATION bin)
 install(TARGETS alacarte-maps-importer RUNTIME DESTINATION bin)
 install(FILES data/config/alacarte-maps.conf DESTINATION ${SYSCONFDIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,145 @@
+cmake_minimum_required( VERSION 2.8.8 )
+
+set(TEST_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+
+# We don't want statistics in our unittests.
+remove_definitions(-DStatistic_Activated)
+
+# check for local static build gmock directory
+SET(GMOCK_FOUND 0)
+IF(EXISTS "${PROJECT_SOURCE_DIR}/gmock" AND IS_DIRECTORY "${PROJECT_SOURCE_DIR}/gmock")
+    link_directories(${Boost_LIBRARY_DIRS} ${Cairo_LIBRARY_DIRS} "${PROJECT_SOURCE_DIR}/gmock")
+    message("gmock dir found\n")
+    SET(GMOCK_FOUND 1)
+ENDIF(EXISTS "${PROJECT_SOURCE_DIR}/gmock" AND IS_DIRECTORY "${PROJECT_SOURCE_DIR}/gmock")
+
+#
+# Sources
+#
+file(GLOB_RECURSE UnitTests_general_sources     general/*.cpp)
+file(GLOB_RECURSE UnitTests_server_sources      server/*.cpp)
+file(GLOB_RECURSE UnitTests_mapcss_sources      mapcss/*.cpp)
+file(GLOB_RECURSE UnitTests_importer_sources    importer/*.cpp)
+file(GLOB_RECURSE UnitTests_utils_sources       utils/*.cpp)
+file(GLOB_RECURSE UnitTests_eval_sources        eval/*.cpp)
+file(GLOB_RECURSE UnitTests_parser_sources      parser/*.cpp)
+file(GLOB_RECURSE UnitTests_shared_sources      shared/*.cpp)
+
+#
+# Targets
+#
+configure_file("config.hpp.in" "${CMAKE_CURRENT_SOURCE_DIR}/config.hpp")
+
+#
+#  Building tests
+#  All sources are rebuilt with ALACARTE_TEST (it is used in .cpp files)
+#
+add_definitions(-DALACARTE_TEST)
+
+add_library(alacarte-obj-test EXCLUDE_FROM_ALL OBJECT ${alacarte_sources})
+add_library(server-obj-test EXCLUDE_FROM_ALL OBJECT ${server_sources})
+add_library(UnitTests-shared-obj EXCLUDE_FROM_ALL OBJECT ${UnitTests_shared_sources})
+
+add_executable(unitTests_utils
+	EXCLUDE_FROM_ALL
+	${UnitTests_utils_sources}
+	$<TARGET_OBJECTS:UnitTests-shared-obj>
+	$<TARGET_OBJECTS:alacarte-obj-test>
+)
+add_executable(unitTests_parser
+	EXCLUDE_FROM_ALL 
+	${UnitTests_parser_sources}
+	$<TARGET_OBJECTS:UnitTests-shared-obj>
+	$<TARGET_OBJECTS:server-obj-test>
+	$<TARGET_OBJECTS:alacarte-obj-test>
+)
+add_executable(unitTests_general
+	EXCLUDE_FROM_ALL
+	${UnitTests_general_sources}
+	$<TARGET_OBJECTS:UnitTests-shared-obj>
+	$<TARGET_OBJECTS:server-obj-test>
+	$<TARGET_OBJECTS:alacarte-obj-test>
+)
+add_executable(unitTests_importer
+	EXCLUDE_FROM_ALL
+	${UnitTests_importer_sources}
+	$<TARGET_OBJECTS:UnitTests-shared-obj>
+	$<TARGET_OBJECTS:alacarte-obj-test>
+)
+add_executable(unitTests_server
+	EXCLUDE_FROM_ALL
+	${UnitTests_server_sources}
+	$<TARGET_OBJECTS:UnitTests-shared-obj>
+	$<TARGET_OBJECTS:server-obj-test>
+	$<TARGET_OBJECTS:alacarte-obj-test>
+)
+
+if(GMOCK_FOUND)
+	add_executable(unitTests_mapcss
+		EXCLUDE_FROM_ALL
+		${UnitTests_mapcss_sources}
+		$<TARGET_OBJECTS:UnitTests-shared-obj>
+		$<TARGET_OBJECTS:server-obj-test>
+		$<TARGET_OBJECTS:alacarte-obj-test>
+	)
+endif(GMOCK_FOUND)
+
+add_executable(unitTests_eval
+	EXCLUDE_FROM_ALL
+	${UnitTests_eval_sources}
+	$<TARGET_OBJECTS:UnitTests-shared-obj>
+	$<TARGET_OBJECTS:server-obj-test>
+	$<TARGET_OBJECTS:alacarte-obj-test>
+)
+
+target_link_libraries(unitTests_utils       ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(unitTests_general     ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(unitTests_importer    ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(unitTests_server      ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SYSTEM_LIBRARIES})
+target_link_libraries(unitTests_parser      ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SYSTEM_LIBRARIES})
+if(GMOCK_FOUND)
+	target_link_libraries(unitTests_mapcss  ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} gmock gtest)
+endif(GMOCK_FOUND)
+target_link_libraries(unitTests_eval        ${Boost_LIBRARIES} ${CAIRO_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${SYSTEM_LIBRARIES})
+
+
+set(test_files
+	"${CMAKE_CURRENT_SOURCE_DIR}/data/input/karlsruhe_big.carte"
+	"${CMAKE_CURRENT_SOURCE_DIR}/data/input/renderer_test.carte"
+	"${CMAKE_CURRENT_SOURCE_DIR}/data/input/test_tiles.carte"
+)
+
+add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/data/input/karlsruhe_big.carte"
+    COMMAND alacarte-maps-importer "${CMAKE_CURRENT_SOURCE_DIR}/data/input/karlsruhe_big.osm" "${CMAKE_CURRENT_SOURCE_DIR}/data/input/karlsruhe_big.carte"
+)
+add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/data/input/test_tiles.carte"
+    COMMAND alacarte-maps-importer "${CMAKE_CURRENT_SOURCE_DIR}/data/input/test_tiles.osm" "${CMAKE_CURRENT_SOURCE_DIR}/data/input/test_tiles.carte"
+)
+add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/data/input/renderer_test.carte"
+    COMMAND alacarte-maps-importer "${CMAKE_CURRENT_SOURCE_DIR}/data/input/renderer_test.osm" "${CMAKE_CURRENT_SOURCE_DIR}/data/input/renderer_test.carte"
+)
+
+add_custom_target(tests ALL DEPENDS
+	alacarte-maps-importer
+	unitTests_server
+	unitTests_importer
+	unitTests_general
+	unitTests_parser
+	unitTests_utils
+	unitTests_eval
+	${test_files}
+)
+
+add_test(unitTests_utils unitTests_utils DEPENDS tests)
+add_test(unitTests_eval unitTests_eval)
+add_test(unitTests_parser unitTests_parser)
+add_test(unitTests_general unitTests_general)
+add_test(unitTests_importer unitTests_importer)
+add_test(unitTests_server unitTests_server)
+
+if(GMOCK_FOUND)
+   add_test(unitTests_mapcss unitTests_mapcss)
+endif(GMOCK_FOUND)


### PR DESCRIPTION
Changes:
- Move unit tests in a separate CMakeLists.txt file
- Replaced `include(CTest)` with `enable_testing()`
  `enable_testing()` is more lightweight and does not generate 20+ targets we don't use.
- Disabled Statistics for the unit tests. Is this correct?

