### PR TITLE
Make Karlsruhe green again!

### DIFF
--- a/data/mapcss/default.mapcss
+++ b/data/mapcss/default.mapcss
@@ -580,6 +580,7 @@ area|z14- [leisure=nature_reserve] {
     text-position: center;
 }
 
+relation[landuse=forest],
 way|z8-[landuse=forest] {
     fill-color: #85c638;
 }

--- a/data/mapcss/default.mapcss
+++ b/data/mapcss/default.mapcss
@@ -602,6 +602,7 @@ way|z10-[leisure=pitch] {
 
 way [natural=water],
 way [waterway=riverbank],
+relation [natural=water],
 relation [waterway=riverbank],
 way|z14-[amenity=fountain] {
     z-index: 1;


### PR DESCRIPTION
Hi,
I made some slide adjustments to the default.mapcss stylesheet.
This does two things:

1. The harbor in Karlruhe was not water-blue, because it is a relation and not only a way:
Before:
![habour-before](https://cloud.githubusercontent.com/assets/4148534/23256691/e2016712-f9c0-11e6-867b-2cc004f38fc2.png)

After:
![habour-after](https://cloud.githubusercontent.com/assets/4148534/23256704/ed04bdee-f9c0-11e6-9f54-d2ad38b1e91a.png)


2. The same problem with forests:
Before:
![park-before](https://cloud.githubusercontent.com/assets/4148534/23256720/064bd742-f9c1-11e6-9cb2-88be1031938f.png)

After:
![park-after](https://cloud.githubusercontent.com/assets/4148534/23256729/0e877c2c-f9c1-11e6-8f6e-bc5187ff1386.png)
