### PR TITLE
added an option to the importer to bound the imported data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.4.0] - 2016-12-28 ##
 ### Added ###
 - man pages for alacarte-importer and alacarte-server.
+- The importer can now limit the area to import via `min-lat`, `max-lat`, `min-lon` and `max-lon` arguments
+  to reduce memory consumption if you don't need the whole area of your source data.
 - support for Debian Jessie (as it's the new stable).
 
 ### Changed ###

--- a/include/general/configuration.hpp
+++ b/include/general/configuration.hpp
@@ -50,7 +50,20 @@ namespace opt {
 		static const char* path_to_geodata			= "importer.geo-data";
 
 		//! Check all xml entities
-		static const char* check_xml_entities = "importer.check-xml-entities";
+		static const char* check_xml_entities		= "importer.check-xml-entities";
+
+		//! minimum node latitude to include into imported data
+		static const char* min_lat					= "importer.min-lat";
+
+		//! minimum node longitude to include into imported data
+		static const char* min_lon					= "importer.min-lon";
+
+		//! maximum node latitude to include into imported data
+		static const char* max_lat					= "importer.max-lat";
+
+		//! maximum node longitude to include into imported data
+		static const char* max_lon					= "importer.max-lon";
+
 	}
 
 	namespace server {
@@ -133,6 +146,19 @@ public:
 	T get(const string& key)
 	{
 		return boost::any_cast<const T&>(getValueByKey(key));
+	}
+
+	/**
+	 * @brief Returns a value identified by a key or a default value if the key does not exist.
+	 *
+	 * @param key the key identifying the value
+	 * @param defaultValue the value that is returned if key does not exist
+	 * @return the value in the identified by the key casted to the wanted type or the default value
+	 **/
+	template<typename T>
+	T get(const string& key, const T& defaultValue)
+	{
+		return has(key)? get<T>(key) : defaultValue;
 	}
 
 	void printConfigToLog();

--- a/src/alacarte_importer.cpp
+++ b/src/alacarte_importer.cpp
@@ -64,6 +64,10 @@ public:
 			(OPT(opt::importer::path_to_geodata, "g"),	value<string>()->required()->default_value("ala.carte")/*->value_name("path")*/,	"path, where preprocessed data will be saved")
 			(OPT(opt::importer::check_xml_entities, "x"),	value<bool>()->required()->default_value(true)/*->value_name("path")*/,			
 				"Specifies weather the parser should not ignore unknown entities.")
+			(opt::importer::min_lat, value<double>(), "minimum node latitude")
+			(opt::importer::min_lon, value<double>(), "minimum node longitude")
+			(opt::importer::max_lat, value<double>(), "maximum node latitude")
+			(opt::importer::max_lon, value<double>(), "maximum node longitude")
 			;
 
 


### PR DESCRIPTION
Because alacarte uses an insane amount of memory, and I have no idea why, I implemented a feature with which you can bound the imported area. Use `min-lat`, `max-lat`, `min-lon`, `max-lon` to specify the rectangular area you want to import.