### PR TITLE
Revert "Fixed boost static library problem"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,6 @@ add_subdirectory(manpages)
 #
 # Depends on boost version from Debian Jessie
 #
-if(MSVC)
-    set(Boost_USE_STATIC_LIBS true)
-endif(MSVC)
 set(BOOST_MIN_VERSION_REQUIRED 1.55.0)
 
 if(MSVC)
@@ -83,8 +80,6 @@ endif()
 
 # Set windows version for windows and Inotify for non-windows targets
 if(WIN32)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_WIN32_WINNT=0x0601")
-    add_definitions(-D_WIN32_WINNT=0x0601)
     set(SYSTEM_LIBRARIES ws2_32 wsock32)
 else()
     include_directories(${INOTIFY_INCLUDE_DIRS})


### PR DESCRIPTION
This reverts commit 86edb188fcdef4a21733cfb41a57734a01a9d4c3.

Commit 86edb18 - "Fixed boost static library problem" introduces duplicated code.
1. Line 19-21 are already covered by Line 24-29
2. Line 87 duplicate of Line 100
3. Line 86 should not be needed as it does the same as Line 87/100.

We may need to pull Line 100 (`add_definitions(-D_WIN32_WINNT=0x0601)`) further up.